### PR TITLE
Fix new staking bugs and do some production adjustment

### DIFF
--- a/src/components/RewardsPage/PoolDetail/index.tsx
+++ b/src/components/RewardsPage/PoolDetail/index.tsx
@@ -64,7 +64,7 @@ const PoolDetail = ({ pool }) => {
     return () => { active = false }
 
     async function loadApr() {
-      if (!active || !hakkaPrice) { return }
+      if (!active || !hakkaPrice || !tokenPrice) { return }
       try {
         const newApr = await POOL_ASSETES[pool].getApr(
           parseUnits(hakkaPrice.toString(), 18),

--- a/src/components/StakingPage/VotingPower/index.tsx
+++ b/src/components/StakingPage/VotingPower/index.tsx
@@ -72,14 +72,14 @@ const VotingPowerArea = (props: VotingPowerAreaProps) => {
           }
         </div>
       </div>
-      <div style={stakingVersion === StakingVersion.V1 ? {display: 'none'} : {}}>
+      {/* <div style={stakingVersion === StakingVersion.V1 ? {display: 'none'} : {}}>
         <p>Proportion (V2 only)</p>
         <div sx={styles.proportionItemContainer}>
           <ProportionItem proportionValue={ethProportion || '-'} img={images.iconEthereumDarkBg} />
           <ProportionItem proportionValue={bscProportion || '-'} img={images.iconBSCDarkBg} />
           <ProportionItem proportionValue={polygonProportion || '-'} img={images.iconPolygonDarkBg} />
         </div>
-      </div>
+      </div> */}
     </div>
   )
 } ;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -271,7 +271,7 @@ export const NEW_SHAKKA_ADDRESSES: { [chainId in ChainId]: string } = {
 };
 
 export const STAKING_RATE_MODEL_RELEASE_TIME: { [address: typeof NEW_SHAKKA_ADDRESSES[ChainId]]: number } = {
-  [NEW_SHAKKA_ADDRESSES[ChainId.MAINNET]]: undefined,
+  [NEW_SHAKKA_ADDRESSES[ChainId.MAINNET]]: 1655110318,
   [NEW_SHAKKA_ADDRESSES[ChainId.KOVAN]]: 1653042448,
   [NEW_SHAKKA_ADDRESSES[ChainId.BSC]]: undefined,
   [NEW_SHAKKA_ADDRESSES[ChainId.POLYGON]]: undefined,

--- a/src/constants/rewards/assets.ts
+++ b/src/constants/rewards/assets.ts
@@ -147,7 +147,7 @@ export const POOL_ASSETES: { [key: string]: PoolAssets } = {
     icon: images.iconIgainLp,
     decimal: 18,
     getApr: getGainAprFunc(IGAIN_FANTOM_ETH_POOL_1, ChainId.FANTOM),
-    getTvl: getGainTvlFunc(IGAIN_FANTOM_ETH_POOL_1, ChainId.FANTOM),
+    getTvl: getGainTvlFunc(IGAIN_FANTOM_ETH_POOL_1, ChainId.FANTOM, 'ethereum'),
     tokenPriceKey: 'ethereum'
   },
 }

--- a/src/containers/VotingPowerContainer/index.tsx
+++ b/src/containers/VotingPowerContainer/index.tsx
@@ -6,7 +6,7 @@ import { ChainId } from '../../constants';
 import useVotingPower from '../../hooks/useVotingPower';
 import { v1PowerWeighting } from '../../utils/votingPowerCal';
 import useV1VotingPower from '../../hooks/useV1VotingPower';
-const startDateSec = ~~(new Date('2022-05-16 17:00:00').getTime() / 1000);
+const startDateSec = ~~(new Date('2022-06-30 18:00:00').getTime() / 1000);
 const availableList = [ChainId.MAINNET, ChainId.BSC, ChainId.POLYGON];
 if (process.env.GATSBY_ENV === 'development') {
   availableList.push(ChainId.KOVAN);
@@ -47,14 +47,24 @@ const VotingPowerContainer = ({ stakingVersion }: VotingPowerContainerProps) => 
       )
     ));
     const totalVotingPower = weightedV1VotingPower.add(weightedV2VotingPower);
-    const v1Proportion = weightedV1VotingPower.div(totalVotingPower).mul(100);
-    const v2Proportion = weightedV2VotingPower.div(totalVotingPower).mul(100);
+    const v1Proportion = totalVotingPower.gt(0) ? weightedV1VotingPower.div(totalVotingPower).mul(100) : 0;
+    const v2Proportion = totalVotingPower.gt(0) ? weightedV2VotingPower.div(totalVotingPower).mul(100) : 0;
+
+    const v2ProportionSum = availableList.reduce(
+      (previousValue, currentChainId) => {
+        if (!votingPowerInfo[currentChainId]) {
+          return previousValue;
+        }
+        return previousValue + parseFloat(formatUnits(votingPowerInfo[currentChainId]));
+      },
+      0
+    );
 
     const v2ProportionList = availableList.map((chainId) => {
       if (!votingPowerInfo[chainId]) {
         return '-';
       }
-      return parseFloat(formatUnits(votingPowerInfo[chainId])).toFixed(2);
+      return (parseFloat(formatUnits(votingPowerInfo[chainId])) / v2ProportionSum * 100).toFixed(2);
     });
     return [
       totalVotingPower?.toFixed(2),

--- a/src/hooks/useCurrentBlockTimestamp.ts
+++ b/src/hooks/useCurrentBlockTimestamp.ts
@@ -6,5 +6,5 @@ import { useMulticallContract } from './useContract';
 export default function useCurrentBlockTimestamp(): BigNumber | undefined {
   const multicall = useMulticallContract();
   return useSingleCallResult(multicall, 'getCurrentBlockTimestamp')
-    ?.result?.[0];
+    ?.result?.[0] || BigNumber.from(~~(Date.now() / 1000));
 }

--- a/src/hooks/useRequestNetworkConfig.ts
+++ b/src/hooks/useRequestNetworkConfig.ts
@@ -18,6 +18,23 @@ export default function useRequestNetworkConfig(targetNetwork: ChainId): any {
           blockExplorerUrls: ['https://bscscan.com/'],
         }],
       }
+    } else if (targetNetwork === ChainId.FANTOM) {
+      return {
+        method: 'wallet_addEthereumChain',
+        params: [
+          {
+            chainId: '0xFA',
+            chainName: 'Fantom',
+            nativeCurrency: {
+              name: 'FTM',
+              symbol: 'FTM',
+              decimals: 18,
+            },
+            rpcUrls: [process.env.GATSBY_FANTOM_NETWORK_URL],
+            blockExplorerUrls: ['https://ftmscan.com/'],
+          },
+        ],
+      };
     } else if (targetNetwork === ChainId.POLYGON) {
       return {
         method: 'wallet_addEthereumChain',

--- a/src/hooks/useSHakkaBalance.ts
+++ b/src/hooks/useSHakkaBalance.ts
@@ -14,7 +14,7 @@ import { useBlockNumber } from '../state/application/hooks';
 import STAKING_ABI from '../constants/abis/shakka.json';
 
 export type SHakkaBalanceType = {
-  [chainId in ChainId]: BigNumber;
+  [chainId in ChainId]?: BigNumber;
 };
 
 export default function useSHakkaBalance(): {
@@ -63,7 +63,8 @@ export default function useSHakkaBalance(): {
       //   getSHakkaBalance(ChainId.KOVAN),
       // ]);
 
-      const [kovanSHakkaBalance, rinkebySHakkaBalance] = await Promise.all([
+      const [ethSHakkaBalance, kovanSHakkaBalance, rinkebySHakkaBalance] = await Promise.all([
+        getSHakkaBalance(ChainId.MAINNET, account),
         getSHakkaBalance(ChainId.KOVAN, account),
         getSHakkaBalance(ChainId.RINKEBY, account),
       ]);
@@ -74,7 +75,7 @@ export default function useSHakkaBalance(): {
       //   [ChainId.POLYGON]: polygonSHakkaBalance,
       //   [ChainId.KOVAN]: kovanSHakkaBalance});
       setSHakkaBalanceInfo({
-        [ChainId.MAINNET]: Zero,
+        [ChainId.MAINNET]: ethSHakkaBalance,
         [ChainId.BSC]: Zero,
         [ChainId.POLYGON]: Zero,
         [ChainId.KOVAN]: kovanSHakkaBalance,

--- a/src/hooks/useStakedHakka.ts
+++ b/src/hooks/useStakedHakka.ts
@@ -16,7 +16,7 @@ import { useBlockNumber } from '../state/application/hooks';
 import STAKING_ABI from '../constants/abis/shakka.json';
 import throttle from 'lodash/throttle';
 export type StakedHakkaType = {
-  [chainId in ChainId]: BigNumber;
+  [chainId in ChainId]?: BigNumber;
 };
 
 export default function useStakedHakka(): {
@@ -68,7 +68,8 @@ export default function useStakedHakka(): {
       //   getStakedHakka(ChainId.KOVAN),
       // ]);
 
-      const [kovanStakedHakka, rinkebyStakedHakka] = await Promise.all([
+      const [ethStakedHakka, kovanStakedHakka, rinkebyStakedHakka] = await Promise.all([
+        getStakedHakka(ChainId.MAINNET, account),
         getStakedHakka(ChainId.KOVAN, account),
         getStakedHakka(ChainId.RINKEBY, account),
       ]);
@@ -80,7 +81,7 @@ export default function useStakedHakka(): {
       //   [ChainId.KOVAN]: kovanStakedHakka});
 
       setStakedHakka({
-        [ChainId.MAINNET]: Zero,
+        [ChainId.MAINNET]: ethStakedHakka,
         [ChainId.BSC]: Zero,
         [ChainId.POLYGON]: Zero,
         [ChainId.KOVAN]: kovanStakedHakka,

--- a/src/hooks/useVotingPower.ts
+++ b/src/hooks/useVotingPower.ts
@@ -64,8 +64,8 @@ export default function useVotingPower(): {
     try {
       const votingPowerList = await Promise.all([
         getVotingPower(ChainId.MAINNET, account),
-        getVotingPower(ChainId.BSC, account),
-        getVotingPower(ChainId.POLYGON, account),
+        [ChainId.BSC, Zero],
+        [ChainId.POLYGON, Zero],
         getVotingPower(ChainId.KOVAN, account),
         getVotingPower(ChainId.RINKEBY, account),
       ]);

--- a/src/utils/rewardsTvl.ts
+++ b/src/utils/rewardsTvl.ts
@@ -107,7 +107,7 @@ export async function balancer2tokenTvl (tokenPrice: any) {
   return pricePerBpt.mul(poolBpt).div(WeiPerEther);
 }
 
-export function getGainTvlFunc (iGainAddress: string, chainId: ChainId): (tokenPrice: any) => Promise<BigNumber> {
+export function getGainTvlFunc(iGainAddress: string, chainId: ChainId, tokenPriceKey?: string): (tokenPrice: any) => Promise<BigNumber> {
   return async function (tokenPrice: any): Promise<BigNumber> {
     const rewardsContract = new MulticallContract(REWARD_POOLS[iGainAddress].rewardsAddress, REWARD_ABI); // farm address
     const igainContract = new MulticallContract(REWARD_POOLS[iGainAddress].tokenAddress, IGAIN_ABI); // igain lp address
@@ -126,6 +126,10 @@ export function getGainTvlFunc (iGainAddress: string, chainId: ChainId): (tokenP
     ]);
     const decimalBNUnit = parseUnits('1', decimals);
     const perLpPrice = poolA.mul(poolB).mul(BigNumber.from(2)).div(poolA.add(poolB)).mul(decimalBNUnit).div(totalSupply);
-    return perLpPrice.mul(stakedTotalSupply).div(decimalBNUnit);
+    const baseTokenTvl = perLpPrice.mul(stakedTotalSupply).div(decimalBNUnit)
+    if(!tokenPriceKey){
+      return baseTokenTvl;
+    }
+    return baseTokenTvl.mul(parseUnits((tokenPrice?.[tokenPriceKey]?.usd || 1.).toString(), decimals)).div(decimalBNUnit);
   };
 }

--- a/src/utils/stakeReceivedAmount.ts
+++ b/src/utils/stakeReceivedAmount.ts
@@ -1,4 +1,4 @@
-import { formatUnits } from 'ethers/lib/utils';
+import { formatUnits, parseUnits } from 'ethers/lib/utils';
 import { ChainId, NEW_SHAKKA_ADDRESSES, SEC_OF_YEAR, STAKING_RATE_MODEL_RELEASE_TIME } from '../constants';
 
 const THIRTY_MINS_FRACTIONS_OF_YEAR = 30/60/24/365.25;
@@ -26,20 +26,20 @@ export function stakeReceivedAmount(
 };
 
 export function restakeReceivedAmount(
-  amount: string, 
+  amount: string,
   time: string, // the unit is year
   vault?: any,
   chainId?: ChainId,
 ): string[] | undefined[] {
-if (!chainId || !vault) { 
-  return [];
-}
-if (parseFloat(time) >  4 || parseFloat(time) < THIRTY_MINS_FRACTIONS_OF_YEAR) {
-  return [];
-}
-const stakingRate = getStakingRate(STAKING_RATE_MODEL_RELEASE_TIME[NEW_SHAKKA_ADDRESSES[chainId]]);
-const totalStakedHakka = parseFloat(formatUnits(vault.hakkaAmount, 18)) + parseFloat(amount);
-const receivedSHakkaAmount = stakeFormula(totalStakedHakka, time, stakingRate);
-const additionalSHakkaAmount = receivedSHakkaAmount - parseFloat(formatUnits(vault.wAmount, 18));
-return [receivedSHakkaAmount.toFixed(4), (~~(additionalSHakkaAmount * 10000) / 10000).toString()];
+  if (!chainId || !vault) {
+    return [];
+  }
+  if (parseFloat(time) > 4 || parseFloat(time) < THIRTY_MINS_FRACTIONS_OF_YEAR) {
+    return [];
+  }
+  const stakingRate = getStakingRate(STAKING_RATE_MODEL_RELEASE_TIME[NEW_SHAKKA_ADDRESSES[chainId]]);
+  const totalStakedHakka = parseFloat(formatUnits(vault.hakkaAmount, 18)) + parseFloat(amount);
+  const receivedSHakkaAmount = stakeFormula(totalStakedHakka, time, stakingRate);
+  const additionalSHakkaAmount = parseUnits(receivedSHakkaAmount.toString(), 18).sub(vault.wAmount);
+  return [receivedSHakkaAmount.toFixed(4), (Math.floor(parseFloat(formatUnits(additionalSHakkaAmount, 18)) * 10000) / 10000).toString()];
 };

--- a/src/utils/votingPowerCal.ts
+++ b/src/utils/votingPowerCal.ts
@@ -1,6 +1,6 @@
 import Decimal from 'decimal.js';
 export const v1PowerWeighting = (hours: number) => {
-  hours = hours >=8766 ? 8766 : hours;
+  hours = hours >=8766 ? 8766 : hours > 0 ? hours: 0;
   // .25(1-x/8766);
   return new Decimal(hours).mul(-0.25).div(8766).add(0.25);
 }


### PR DESCRIPTION
  -remove proportion v2 section
  -voting power hours lower bounds set to 0
  -~~ to Math.floor to avoid overflow
  -getGainTvlFunc add key to get correct eth tvl in dollars
  -fetchVotingPower has no bsc and polygon contract, set to zero
  -fetchStakedHakka add eth
  -fetchSHakkaBalance add eth
  -useRequestNetworkConfig add fantom
  -useCurrentBlockTimestamp use default time now to avoid incorrect chain issue
  -totalVotingPower avoid NaN
  -V2 proportion add sum for division
  -add STAKING_RATE_MODEL_RELEASE_TIME for main net

clickup: CU-31mevp1